### PR TITLE
XDR-440: Add region-specific provider for CMK module

### DIFF
--- a/examples/aws-kms-master-key/main.tf
+++ b/examples/aws-kms-master-key/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.22.0"
+      version = "~> 3.28"
     }
   }
 }
@@ -12,8 +12,17 @@ provider "aws" {
   region = "ap-southeast-1"
 }
 
+provider "aws" {
+  alias  = "cmk"
+  region = "us-east-1"
+}
+
 module "aws_kms_master_key" {
   source = "../../modules/aws-kms-master-key"
+
+  providers = {
+    aws.cmk = aws.cmk
+  }
 
   name                                = var.name
   deletion_window_in_days             = var.deletion_window_in_days

--- a/modules/aws-kms-master-key/main.tf
+++ b/modules/aws-kms-master-key/main.tf
@@ -4,6 +4,22 @@
 
 terraform {
   required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# CREATE AN ALIASED PROVIDER WITH THE TARGET REGION
+# We're doing this here instead of the calling module to preserve support for `for_each`, `count` and `depends_on`.
+# ----------------------------------------------------------------------------------------------------------------------
+
+provider "aws" {
+  alias = "cmk"
 }
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -11,6 +27,8 @@ terraform {
 # ----------------------------------------------------------------------------------------------------------------------
 
 resource "aws_kms_key" "master_key" {
+  provider = aws.cmk
+
   description              = "The ${var.name} customer master key."
   policy                   = data.aws_iam_policy_document.policy.json
   deletion_window_in_days  = var.deletion_window_in_days
@@ -77,6 +95,8 @@ data "aws_iam_policy_document" "policy" {
 # ----------------------------------------------------------------------------------------------------------------------
 
 resource "aws_kms_alias" "master_key" {
+  provider = aws.cmk
+
   name          = "alias/${var.name}"
   target_key_id = aws_kms_key.master_key.id
 }


### PR DESCRIPTION
Adds an aliased provider so the CMK module can provision keys into specific regions other than the default.

Even though our Terragrunt implementation provides the `aws_region` variable automatically in the root `terragrunt.hcl`, this is marked **breaking** because the addition of a non-optional variable is breaking for vanilla Terraform users.