### PR TITLE
EN-469: Add versioning_enabled to log S3 bucket (fix)

### DIFF
--- a/modules/aws-s3-private/main.tf
+++ b/modules/aws-s3-private/main.tf
@@ -81,6 +81,10 @@ resource "aws_s3_bucket" "private_s3_logs" {
   bucket = local.logging_bucket_name
   acl    = "log-delivery-write"
 
+  versioning {
+    enabled = var.versioning_enabled
+  }
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {


### PR DESCRIPTION
The `private_s3_logs` S3 bucket did not have `versioning`
enabled, and TFsec was showing errors because of that.
This fixes that.

The error from TFsec follows

```
git commit -m 'Create S3 bucket for AWS Config'
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/gerardsetho/.cache/pre-commit/patch1625555482-42681.
Check for added large files..............................................Passed
Check for byte-order marker..............................................Passed
Check for case conflicts.................................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check JSON...........................................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check for broken symlinks............................(no files to check)Skipped
Check Yaml...........................................(no files to check)Skipped
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Terraform fmt............................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate with tfsec............................................Failed
- hook id: terraform_tfsec
- exit code: 1

Check 1

  [AWS077][ERROR] Resource 'module.s3_private:aws_s3_bucket.private_s3_logs' does not have versioning enabled
  /Users/gerardsetho/dev/qs/package-aws-security/modules/aws-s3-private/main.tf:77-100


      74 | # CREATE A BUCKET TO TARGET S3 LOGGING
      75 | # ----------------------------------------------------------------------------------------------------------------------
      76 | 
      77 | resource "aws_s3_bucket" "private_s3_logs" {
      78 |   # only create this bucket if logging_bucket_name is not specified
      79 |   count = var.logging_enabled && try(length(var.logging_bucket_name), 0) == 0 ? 1 : 0
      80 | 
      81 |   bucket = local.logging_bucket_name
      82 |   acl    = "log-delivery-write"
      83 | 
      84 |   server_side_encryption_configuration {
      85 |     rule {
      86 |       apply_server_side_encryption_by_default {
      87 |         sse_algorithm     = var.sse_algorithm
      88 |         kms_master_key_id = var.kms_master_key_arn
      89 |       }
      90 |     }
      91 |   }
      92 | 
      93 |   # We can not configure the logging bucket to be a WORM bucket.
      94 |   # https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes
      95 |   # S3 buckets with S3 Object Lock cannot be used as destination buckets for Amazon S3 server access logging
      96 | 
      97 |   tags = var.tags
      98 | 
      99 |   force_destroy = var.force_destroy
     100 | }
     101 | 
     102 | data "aws_s3_bucket" "existing_private_s3_logs" {
     103 |   # only lookup this bucket if logging_bucket_name is specified

  Impact:     Deleted or modified data would not be recoverable
  Resolution: Enable versioning to protect against accidental/malicious removal or modification

  https://tfsec.dev/docs/aws/AWS077/ 
  https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html 
  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#versioning 

  times
  ------------------------------------------
  disk i/o             6.627113ms
  parsing HCL          20.026µs
  evaluating values    1.414409ms
  running checks       1.018786ms

  counts
  ------------------------------------------
  files loaded         5
  blocks               4
  evaluated blocks     34
  modules              1
  module blocks        30
  ignored checks       0

1 potential problems detected.
```