### PR TITLE
EN-490: Add AWS Role granting support access

### DIFF
--- a/examples/aws-roles-default/vars.tf
+++ b/examples/aws-roles-default/vars.tf
@@ -25,6 +25,12 @@ variable "developer_from_accounts" {
   default     = []
 }
 
+variable "support_from_accounts" {
+  description = "A list of AWS principals (ARNs) permitted to assume the support-from-external-accounts role. If not set then the role will not be created."
+  type        = set(string)
+  default     = []
+}
+
 variable "developer_include_managed_policies" {
   type = list(string)
   default = [
@@ -56,6 +62,12 @@ variable "my_custom_policies" {
   }
 }
 
+variable "policy_name_static_prefix" {
+  description = "A static string that will be prefixed to the name of the policy."
+  type        = string
+  default     = "example_"
+}
+
 variable "role_name_static_prefix" {
   description = "A static string that will be prefixed to the name of the role. This is not the same as `name_prefix` in that it does not generate a unique name, but instead provides a static string prefix to the role name."
   type        = string
@@ -68,6 +80,7 @@ variable "included_default_policy_names" {
   default = [
     "auto_deploy_from_external_accounts",
     "developer_from_external_accounts",
+    "support_from_external_accounts",
   ]
 }
 

--- a/modules/aws-iam-roles/vars.tf
+++ b/modules/aws-iam-roles/vars.tf
@@ -11,6 +11,12 @@ variable "aws_account_id" {
 # OPTIONAL MODULE PARAMETERS
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "policy_name_static_prefix" {
+  description = "A static string that will be prefixed to the name of the policy."
+  type        = string
+  default     = ""
+}
+
 variable "role_name_static_prefix" {
   description = "A static string that will be prefixed to the name of the role. This is not the same as `name_prefix` in that it does not generate a unique name, but instead provides a static string prefix to the role name."
   type        = string
@@ -220,8 +226,36 @@ variable "self_manage_policy" {
   default = null
 }
 
+variable "support_from_external_accounts_policy" {
+  description = "A policy that will completely overwrite the default support_policy policy."
+  type = object({
+    name                 = string
+    description          = string
+    path                 = string
+    policy               = string
+    service_principals   = list(string)
+    aws_principals       = list(string)
+    federated_principals = list(string)
+    iam_policy_arns      = list(string)
+    role_requires_mfa    = bool
+  })
+  default = null
+}
+
 variable "developer_from_accounts" {
   description = "A list of AWS principals (ARNs) permitted to assume the developer-from-external-accounts role."
+  type        = set(string)
+  default     = []
+}
+
+variable "self_manage_from_accounts" {
+  description = "A list of AWS principals (ARNs) permitted to assume the self_manage role."
+  type        = set(string)
+  default     = []
+}
+
+variable "support_from_accounts" {
+  description = "A list of AWS principals (ARNs) permitted to assume the support role."
   type        = set(string)
   default     = []
 }


### PR DESCRIPTION
- [x] Add support role attaching `arn:aws:iam::aws:policy/AWSSupportAccess`
- [x] Require MFA to use the role and perform actions within the policy

---

Addresses CIS Benchmark
Policy: CIS AWS Web Services Foundations Benchmark
Control Name: Ensure a support role has been created to manage incidents with AWS Support
Criticality: HIGH

<details>
<summary><code>terraform plan</code></summary>

```terraform
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.roles.aws_iam_role_policy_attachment.policy["support_from_external_accounts"] will be created
  + resource "aws_iam_role_policy_attachment" "policy" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = (known after apply)
    }

  # module.roles.module.policy["support_from_external_accounts"].aws_iam_policy.policy will be created
  + resource "aws_iam_policy" "policy" {
      + arn         = (known after apply)
      + description = "The policy providing access for managing ones own iam user and use AWS Support"
      + id          = (known after apply)
      + name        = "example_support_from_external_accounts"
      + path        = "/examples/aws-roles-default/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "iam:ListVirtualMFADevices"
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "AllowViewAccountInfo"
                    },
                  + {
                      + Action   = [
                          + "iam:DeleteVirtualMFADevice",
                          + "iam:CreateVirtualMFADevice",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:iam::503776578075:mfa/${aws:username}"
                      + Sid      = "AllowManageOwnVirtualMFADevice"
                    },
                  + {
                      + Action   = [
                          + "iam:ResyncMFADevice",
                          + "iam:ListMFADevices",
                          + "iam:GetUser",
                          + "iam:EnableMFADevice",
                          + "iam:DeactivateMFADevice",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:iam::503776578075:user/${aws:username}",
                          + "arn:aws:iam::503776578075:mfa/${aws:username}",
                        ]
                      + Sid      = "AllowManageOwnUserMFA"
                    },
                  + {
                      + Condition = {
                          + Bool = {
                              + aws:MultiFactorAuthPresent = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + NotAction = [
                          + "sts:GetSessionToken",
                          + "iam:ResyncMFADevice",
                          + "iam:ListVirtualMFADevices",
                          + "iam:ListMFADevices",
                          + "iam:GetUser",
                          + "iam:EnableMFADevice",
                          + "iam:CreateVirtualMFADevice",
                        ]
                      + Resource  = "*"
                      + Sid       = "DenyAllExceptListedIfNoMFA"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }

  # module.roles.module.role["support_from_external_accounts"].aws_iam_role.role will be created
  + resource "aws_iam_role" "role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Condition = {
                          + Bool = {
                              + aws:MultiFactorAuthPresent = "true"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::503776578075:root"
                        }
                      + Sid       = "AssumeRoleExampleSupport"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "example-support"
      + path                  = "/examples/aws-roles-default/"
      + tags                  = {
          + "cost_center" = "engineering"
        }
      + unique_id             = (known after apply)
    }

  # module.roles.module.role["support_from_external_accounts"].aws_iam_role_policy_attachment.policy["arn:aws:iam::aws:policy/AWSSupportAccess"] will be created
  + resource "aws_iam_role_policy_attachment" "policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AWSSupportAccess"
      + role       = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + roles_and_policies = {
      + policies = {
          + support_from_external_accounts = {
              + arn = (known after apply)
              + id  = (known after apply)
            }
        }
      + roles    = {
          + support_from_external_accounts = {
              + arn = (known after apply)
              + id  = (known after apply)
            }
        }
    }

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```
</details>